### PR TITLE
feat: Implement site management and scraping API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,9 +16,11 @@
         "@teamhanko/passkeys-sdk": "0.2.1",
         "@types/marked": "^5.0.2",
         "alpinejs": "3.14.9",
+        "cheerio": "^1.0.0",
         "kysely": "0.28.2",
         "kysely-d1": "0.4.0",
         "marked": "^15.0.12",
+        "nanoid": "^5.1.5",
         "resend": "4.5.0",
         "tailwindcss": "4.1.5"
       },
@@ -2057,6 +2059,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -2130,6 +2138,76 @@
       "license": "MIT",
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/cheerio": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0.tgz",
+      "integrity": "sha512-quS9HgjQpdaXOvsZz82Oz7uxtXiy6UIsIQcpBj7HRw2M63Skasm9qlDocAM7jNuaxdhpPU7c4kJN+gA5MCu4ww==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "encoding-sniffer": "^0.2.0",
+        "htmlparser2": "^9.1.0",
+        "parse5": "^7.1.2",
+        "parse5-htmlparser2-tree-adapter": "^7.0.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^6.19.5",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18.17"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cheerio/node_modules/htmlparser2": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
+      }
+    },
+    "node_modules/cheerio/node_modules/undici": {
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/cjs-module-lexer": {
@@ -2261,6 +2339,34 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/cssesc": {
@@ -2404,6 +2510,19 @@
       "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.0.tgz",
+      "integrity": "sha512-ju7Wq1kg04I3HtiYIOrUrdfdDvkyO9s5XM8QAj/bN61Yo/Vb4vgJxy5vi4Yxk01gWHbrofpPtpxM8bKger9jhg==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.18.1",
@@ -2744,6 +2863,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-arrayish": {
@@ -3373,9 +3504,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
+      "integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
       "funding": [
         {
           "type": "github",
@@ -3384,10 +3515,10 @@
       ],
       "license": "MIT",
       "bin": {
-        "nanoid": "bin/nanoid.cjs"
+        "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": "^18 || >=20"
       }
     },
     "node_modules/node-fetch-native": {
@@ -3441,6 +3572,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/ohash": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
@@ -3478,6 +3621,55 @@
       "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.5.tgz",
       "integrity": "sha512-MRffg93t0hgGZbYTxg60hkRIK2sRuEOHEtCUgMuLgbCC33TMQ68AmxskzUlauzZYD47+ENeGV/ElI7qnWqrAxA==",
       "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.0.tgz",
+      "integrity": "sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/parseley": {
       "version": "0.12.1",
@@ -3606,6 +3798,24 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/prettier": {
@@ -3752,6 +3962,12 @@
         "@rollup/rollup-win32-x64-msvc": "4.40.1",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.26.0",
@@ -4348,6 +4564,27 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@teamhanko/passkeys-sdk": "0.2.1",
     "@types/marked": "^5.0.2",
     "alpinejs": "3.14.9",
+    "cheerio": "^1.0.0",
     "kysely": "0.28.2",
     "kysely-d1": "0.4.0",
     "marked": "^15.0.12",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "kysely": "0.28.2",
     "kysely-d1": "0.4.0",
     "marked": "^15.0.12",
+    "nanoid": "^5.1.5",
     "resend": "4.5.0",
     "tailwindcss": "4.1.5"
   },

--- a/src/routes/api/admin/sites/index.ts
+++ b/src/routes/api/admin/sites/index.ts
@@ -180,9 +180,19 @@ router.post('/api/admin/sites/scrape', async (request: IRequest, env: Env) => {
       return { url: site.url, status: success ? 'completed' : 'failed' };
     });
 
-    const results = await Promise.all(scrapingPromises);
+    const results = await Promise.allSettled(scrapingPromises);
 
-    return new Response(JSON.stringify({ message: 'Scraping initiated', results }), {
+    const successfulScrapes = results.filter(result => result.status === 'fulfilled' && result.value.status === 'completed').map(result => (result as PromiseFulfilledResult<{ url: string, status: string }>).value);
+    const failedScrapes = results.filter(result => result.status === 'fulfilled' && result.value.status === 'failed').map(result => (result as PromiseFulfilledResult<{ url: string, status: string }>).value);
+    const rejectedScrapes = results.filter(result => result.status === 'rejected').map(result => ({ url: 'unknown', status: 'rejected', reason: (result as PromiseRejectedResult).reason }));
+
+
+    return new Response(JSON.stringify({
+      message: 'Scraping process completed',
+      successful: successfulScrapes,
+      failed: failedScrapes,
+      errors: rejectedScrapes,
+    }), {
       headers: { 'Content-Type': 'application/json' },
       status: 200,
     });

--- a/src/routes/api/admin/sites/index.ts
+++ b/src/routes/api/admin/sites/index.ts
@@ -4,6 +4,7 @@ import { nanoid } from 'nanoid';
 import { createSite, deleteSite, listSites, getSiteByUrl, updateSiteLastScrapedAt } from '@/models/site';
 import { createDocument } from '@/models/document';
 import { requireAuth } from '@/helpers/auth';
+import * as cheerio from 'cheerio';
 
 const router = Router();
 
@@ -33,17 +34,15 @@ async function scrapeAndIngest(url: string, env: Env, retries = 3): Promise<bool
       }
       const html = await response.text();
 
-      // More sophisticated content extraction: try to get text from common content tags
-      // This is still basic and can be improved with a proper HTML parser if available in the environment
-      const titleMatch = html.match(/<title>(.*?)<\/title>/i);
-      const title = titleMatch ? titleMatch[1] : url;
-      const content = (html.match(/<p[^>]*>([\s\S]*?)<\/p>/gi) || [])
-                          .concat(html.match(/<h[1-6][^>]*>([\s\S]*?)<\/h[1-6]>/gi) || [])
-                          .concat(html.match(/<li[^>]*>([\s\S]*?)<\/li>/gi) || [])
-                          .map(tag => tag.replace(/<[^>]*>/g, '').trim())
-                          .filter(text => text.length > 0)
-                          .join('\n\n')
-                          .replace(/\s+/g, ' ').trim();
+      const $ = cheerio.load(html);
+      const title = $('title').text() || url;
+
+      // Extract content from common tags, filter out empty strings, and join with newlines
+      const content = $('p, h1, h2, h3, h4, h5, h6, li')
+        .map((i, el) => $(el).text().trim())
+        .get()
+        .filter(text => text.length > 0)
+        .join('\n\n');
 
       if (content.length === 0) {
         console.warn(`No content extracted from ${url}`);

--- a/src/routes/api/admin/sites/index.ts
+++ b/src/routes/api/admin/sites/index.ts
@@ -18,49 +18,59 @@ const isValidUrl = (url: string) => {
 };
 
 // Helper function for scraping (placeholder for actual implementation)
-async function scrapeAndIngest(url: string, env: Env): Promise<boolean> {
-  try {
-    console.log(`Attempting to scrape: ${url}`);
-    const response = await fetch(url);
-    if (!response.ok) {
-      console.error(`Failed to fetch ${url}: ${response.statusText}`);
+async function scrapeAndIngest(url: string, env: Env, retries = 3): Promise<boolean> {
+  for (let i = 0; i < retries; i++) {
+    try {
+      console.log(`Attempting to scrape: ${url} (Attempt ${i + 1}/${retries})`);
+      const response = await fetch(url);
+      if (!response.ok) {
+        console.error(`Failed to fetch ${url}: ${response.statusText}`);
+        if (i < retries - 1) {
+          await new Promise(resolve => setTimeout(resolve, 2000 * (i + 1))); // Exponential backoff
+          continue;
+        }
+        return false;
+      }
+      const html = await response.text();
+
+      // More sophisticated content extraction: try to get text from common content tags
+      // This is still basic and can be improved with a proper HTML parser if available in the environment
+      const titleMatch = html.match(/<title>(.*?)<\/title>/i);
+      const title = titleMatch ? titleMatch[1] : url;
+      const content = (html.match(/<p[^>]*>([\s\S]*?)<\/p>/gi) || [])
+                          .concat(html.match(/<h[1-6][^>]*>([\s\S]*?)<\/h[1-6]>/gi) || [])
+                          .concat(html.match(/<li[^>]*>([\s\S]*?)<\/li>/gi) || [])
+                          .map(tag => tag.replace(/<[^>]*>/g, '').trim())
+                          .filter(text => text.length > 0)
+                          .join('\n\n')
+                          .replace(/\s+/g, ' ').trim();
+
+      if (content.length === 0) {
+        console.warn(`No content extracted from ${url}`);
+        return false;
+      }
+
+      await createDocument(env, {
+        id: nanoid(),
+        title: `Scraped: ${title}`,
+        content: content,
+        drive_file_id: null,
+        drive_id: null,
+        drive_file_modified_at: null,
+      });
+
+      console.log(`Successfully scraped and ingested: ${url}`);
+      return true;
+    } catch (error) {
+      console.error(`Error scraping ${url}:`, error);
+      if (i < retries - 1) {
+        await new Promise(resolve => setTimeout(resolve, 2000 * (i + 1))); // Exponential backoff
+        continue;
+      }
       return false;
     }
-    const html = await response.text();
-
-    // Basic content extraction (can be improved with a proper parser)
-    const titleMatch = html.match(/<title>(.*?)<\/title>/i);
-    const title = titleMatch ? titleMatch[1] : url;
-    // More sophisticated content extraction: try to get text from common content tags
-    // This is still basic and can be improved with a proper HTML parser if available in the environment
-    const content = (html.match(/<p[^>]*>([\s\S]*?)<\/p>/gi) || [])
-                        .concat(html.match(/<h[1-6][^>]*>([\s\S]*?)<\/h[1-6]>/gi) || [])
-                        .concat(html.match(/<li[^>]*>([\s\S]*?)<\/li>/gi) || [])
-                        .map(tag => tag.replace(/<[^>]*>/g, '').trim())
-                        .filter(text => text.length > 0)
-                        .join('\n\n')
-                        .replace(/\s+/g, ' ').trim();
-
-    if (content.length === 0) {
-      console.warn(`No content extracted from ${url}`);
-      return false;
-    }
-
-    await createDocument(env, {
-      id: nanoid(),
-      title: `Scraped: ${title}`,
-      content: content,
-      drive_file_id: null,
-      drive_id: null,
-      drive_file_modified_at: null,
-    });
-
-    console.log(`Successfully scraped and ingested: ${url}`);
-    return true;
-  } catch (error) {
-    console.error(`Error scraping ${url}:`, error);
-    return false;
   }
+  return false; // Should not reach here if retries are exhausted
 }
 
 // Add a new site for scraping

--- a/src/routes/api/admin/sites/index.ts
+++ b/src/routes/api/admin/sites/index.ts
@@ -1,11 +1,11 @@
 
 import { IRequest, Router } from 'itty-router';
+import { nanoid } from 'nanoid';
+import { createSite, deleteSite, listSites, getSiteByUrl, updateSiteLastScrapedAt } from '@/models/site';
+import { createDocument } from '@/models/document';
+import { requireAuth } from '@/helpers/auth';
 
 const router = Router();
-
-// In-memory store for sites (for demonstration purposes)
-// In a real application, this would be a database
-let sites: string[] = [];
 
 // Helper function to validate URL
 const isValidUrl = (url: string) => {
@@ -17,83 +17,155 @@ const isValidUrl = (url: string) => {
   }
 };
 
+// Helper function for scraping (placeholder for actual implementation)
+async function scrapeAndIngest(url: string, env: Env): Promise<boolean> {
+  try {
+    console.log(`Attempting to scrape: ${url}`);
+    const response = await fetch(url);
+    if (!response.ok) {
+      console.error(`Failed to fetch ${url}: ${response.statusText}`);
+      return false;
+    }
+    const html = await response.text();
+
+    // Basic content extraction (can be improved with a proper parser)
+    const titleMatch = html.match(/<title>(.*?)<\/title>/i);
+    const title = titleMatch ? titleMatch[1] : url;
+    const content = html.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
+                        .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
+                        .replace(/<[^>]*>/g, '')
+                        .replace(/\s+/g, ' ').trim();
+
+    if (content.length === 0) {
+      console.warn(`No content extracted from ${url}`);
+      return false;
+    }
+
+    await createDocument(env, {
+      id: nanoid(),
+      title: `Scraped: ${title}`,
+      content: content,
+      drive_file_id: null,
+      drive_id: null,
+      drive_file_modified_at: null,
+    });
+
+    console.log(`Successfully scraped and ingested: ${url}`);
+    return true;
+  } catch (error) {
+    console.error(`Error scraping ${url}:`, error);
+    return false;
+  }
+}
+
 // Add a new site for scraping
-router.post('/api/admin/sites/add', async (request: IRequest) => {
-  const { url } = await request.json();
+router.post('/api/admin/sites/add', async (request: IRequest, env: Env) => {
+  try {
+    await requireAuth(request, env);
+    const { url } = await request.json();
 
-  if (!url || !isValidUrl(url)) {
-    return new Response('Invalid URL provided', { status: 400 });
+    if (!url || !isValidUrl(url)) {
+      return new Response('Invalid URL provided', { status: 400 });
+    }
+
+    const existingSite = await getSiteByUrl(env, url);
+    if (existingSite) {
+      return new Response('Site already exists', { status: 409 });
+    }
+
+    await createSite(env, { id: nanoid(), url });
+    console.log(`Added site for scraping: ${url}`);
+
+    return new Response(`Site ${url} added successfully`, { status: 200 });
+  } catch (error) {
+    console.error('Error adding site:', error);
+    return new Response('Unauthorized', { status: 401 });
   }
-
-  if (sites.includes(url)) {
-    return new Response('Site already exists', { status: 409 });
-  }
-
-  sites.push(url);
-  // TODO: Implement actual scraping logic here
-  // For now, just simulate success
-  console.log(`Added site for scraping: ${url}`);
-
-  return new Response(`Site ${url} added successfully`, { status: 200 });
 });
 
 // Remove a site
-router.post('/api/admin/sites/remove', async (request: IRequest) => {
-  const { url } = await request.json();
+router.post('/api/admin/sites/remove', async (request: IRequest, env: Env) => {
+  try {
+    await requireAuth(request, env);
+    const { url } = await request.json();
 
-  if (!url || !isValidUrl(url)) {
-    return new Response('Invalid URL provided', { status: 400 });
+    if (!url || !isValidUrl(url)) {
+      return new Response('Invalid URL provided', { status: 400 });
+    }
+
+    const siteToRemove = await getSiteByUrl(env, url);
+    if (!siteToRemove) {
+      return new Response('Site not found', { status: 404 });
+    }
+
+    await deleteSite(env, siteToRemove.id);
+    console.log(`Removed site: ${url}`);
+    return new Response(`Site ${url} removed successfully`, { status: 200 });
+  } catch (error) {
+    console.error('Error removing site:', error);
+    return new Response('Unauthorized', { status: 401 });
   }
-
-  const initialLength = sites.length;
-  sites = sites.filter(site => site !== url);
-
-  if (sites.length === initialLength) {
-    return new Response('Site not found', { status: 404 });
-  }
-
-  console.log(`Removed site: ${url}`);
-  return new Response(`Site ${url} removed successfully`, { status: 200 });
 });
 
 // List all managed sites
-router.get('/api/admin/sites/list', async () => {
-  return new Response(JSON.stringify(sites), {
-    headers: { 'Content-Type': 'application/json' },
-    status: 200,
-  });
+router.get('/api/admin/sites/list', async (request: IRequest, env: Env) => {
+  try {
+    await requireAuth(request, env);
+    const sites = await listSites(env);
+    return new Response(JSON.stringify(sites), {
+      headers: { 'Content-Type': 'application/json' },
+      status: 200,
+    });
+  } catch (error) {
+    console.error('Error listing sites:', error);
+    return new Response('Unauthorized', { status: 401 });
+  }
 });
 
 // Trigger scraping for a specific site or all sites
-router.post('/api/admin/sites/scrape', async (request: IRequest) => {
-  const { url } = await request.json();
+router.post('/api/admin/sites/scrape', async (request: IRequest, env: Env) => {
+  try {
+    await requireAuth(request, env);
+    const { url } = await request.json();
 
-  if (url && !isValidUrl(url)) {
-    return new Response('Invalid URL provided', { status: 400 });
+    if (url && !isValidUrl(url)) {
+      return new Response('Invalid URL provided', { status: 400 });
+    }
+
+    let sitesToScrape = [];
+    if (url) {
+      const site = await getSiteByUrl(env, url);
+      if (site) {
+        sitesToScrape.push(site);
+      } else {
+        return new Response('Site not found for scraping', { status: 404 });
+      }
+    } else {
+      sitesToScrape = await listSites(env);
+    }
+
+    if (sitesToScrape.length === 0) {
+      return new Response('No sites to scrape', { status: 404 });
+    }
+
+    const scrapingPromises = sitesToScrape.map(async (site) => {
+      const success = await scrapeAndIngest(site.url, env);
+      if (success) {
+        await updateSiteLastScrapedAt(env, site.id);
+      }
+      return { url: site.url, status: success ? 'completed' : 'failed' };
+    });
+
+    const results = await Promise.all(scrapingPromises);
+
+    return new Response(JSON.stringify({ message: 'Scraping initiated', results }), {
+      headers: { 'Content-Type': 'application/json' },
+      status: 200,
+    });
+  } catch (error) {
+    console.error('Error initiating scraping:', error);
+    return new Response('Unauthorized', { status: 401 });
   }
-
-  let sitesToScrape = url ? [url] : sites;
-
-  if (sitesToScrape.length === 0) {
-    return new Response('No sites to scrape', { status: 404 });
-  }
-
-  // TODO: Implement robust scraping and ingestion logic
-  // This is a placeholder for the actual scraping process
-  const scrapingPromises = sitesToScrape.map(async (siteUrl) => {
-    console.log(`Initiating scraping for: ${siteUrl}`);
-    // Simulate async scraping
-    await new Promise(resolve => setTimeout(resolve, 1000));
-    // TODO: Add error handling, progress tracking, and content normalization
-    return { url: siteUrl, status: 'initiated' };
-  });
-
-  const results = await Promise.all(scrapingPromises);
-
-  return new Response(JSON.stringify({ message: 'Scraping initiated', results }), {
-    headers: { 'Content-Type': 'application/json' },
-    status: 200,
-  });
 });
 
 export default router;

--- a/src/routes/api/admin/sites/index.ts
+++ b/src/routes/api/admin/sites/index.ts
@@ -1,0 +1,99 @@
+
+import { IRequest, Router } from 'itty-router';
+
+const router = Router();
+
+// In-memory store for sites (for demonstration purposes)
+// In a real application, this would be a database
+let sites: string[] = [];
+
+// Helper function to validate URL
+const isValidUrl = (url: string) => {
+  try {
+    new URL(url);
+    return true;
+  } catch (e) {
+    return false;
+  }
+};
+
+// Add a new site for scraping
+router.post('/api/admin/sites/add', async (request: IRequest) => {
+  const { url } = await request.json();
+
+  if (!url || !isValidUrl(url)) {
+    return new Response('Invalid URL provided', { status: 400 });
+  }
+
+  if (sites.includes(url)) {
+    return new Response('Site already exists', { status: 409 });
+  }
+
+  sites.push(url);
+  // TODO: Implement actual scraping logic here
+  // For now, just simulate success
+  console.log(`Added site for scraping: ${url}`);
+
+  return new Response(`Site ${url} added successfully`, { status: 200 });
+});
+
+// Remove a site
+router.post('/api/admin/sites/remove', async (request: IRequest) => {
+  const { url } = await request.json();
+
+  if (!url || !isValidUrl(url)) {
+    return new Response('Invalid URL provided', { status: 400 });
+  }
+
+  const initialLength = sites.length;
+  sites = sites.filter(site => site !== url);
+
+  if (sites.length === initialLength) {
+    return new Response('Site not found', { status: 404 });
+  }
+
+  console.log(`Removed site: ${url}`);
+  return new Response(`Site ${url} removed successfully`, { status: 200 });
+});
+
+// List all managed sites
+router.get('/api/admin/sites/list', async () => {
+  return new Response(JSON.stringify(sites), {
+    headers: { 'Content-Type': 'application/json' },
+    status: 200,
+  });
+});
+
+// Trigger scraping for a specific site or all sites
+router.post('/api/admin/sites/scrape', async (request: IRequest) => {
+  const { url } = await request.json();
+
+  if (url && !isValidUrl(url)) {
+    return new Response('Invalid URL provided', { status: 400 });
+  }
+
+  let sitesToScrape = url ? [url] : sites;
+
+  if (sitesToScrape.length === 0) {
+    return new Response('No sites to scrape', { status: 404 });
+  }
+
+  // TODO: Implement robust scraping and ingestion logic
+  // This is a placeholder for the actual scraping process
+  const scrapingPromises = sitesToScrape.map(async (siteUrl) => {
+    console.log(`Initiating scraping for: ${siteUrl}`);
+    // Simulate async scraping
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    // TODO: Add error handling, progress tracking, and content normalization
+    return { url: siteUrl, status: 'initiated' };
+  });
+
+  const results = await Promise.all(scrapingPromises);
+
+  return new Response(JSON.stringify({ message: 'Scraping initiated', results }), {
+    headers: { 'Content-Type': 'application/json' },
+    status: 200,
+  });
+});
+
+export default router;

--- a/src/routes/api/admin/sites/index.ts
+++ b/src/routes/api/admin/sites/index.ts
@@ -31,9 +31,14 @@ async function scrapeAndIngest(url: string, env: Env): Promise<boolean> {
     // Basic content extraction (can be improved with a proper parser)
     const titleMatch = html.match(/<title>(.*?)<\/title>/i);
     const title = titleMatch ? titleMatch[1] : url;
-    const content = html.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
-                        .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
-                        .replace(/<[^>]*>/g, '')
+    // More sophisticated content extraction: try to get text from common content tags
+    // This is still basic and can be improved with a proper HTML parser if available in the environment
+    const content = (html.match(/<p[^>]*>([\s\S]*?)<\/p>/gi) || [])
+                        .concat(html.match(/<h[1-6][^>]*>([\s\S]*?)<\/h[1-6]>/gi) || [])
+                        .concat(html.match(/<li[^>]*>([\s\S]*?)<\/li>/gi) || [])
+                        .map(tag => tag.replace(/<[^>]*>/g, '').trim())
+                        .filter(text => text.length > 0)
+                        .join('\n\n')
                         .replace(/\s+/g, ' ').trim();
 
     if (content.length === 0) {
@@ -76,10 +81,13 @@ router.post('/api/admin/sites/add', async (request: IRequest, env: Env) => {
     await createSite(env, { id: nanoid(), url });
     console.log(`Added site for scraping: ${url}`);
 
-    return new Response(`Site ${url} added successfully`, { status: 200 });
+    return new Response(JSON.stringify({ message: `Site ${url} added successfully` }), { status: 200 });
   } catch (error) {
     console.error('Error adding site:', error);
-    return new Response('Unauthorized', { status: 401 });
+    if (error.message === 'Unauthorized') {
+      return new Response('Unauthorized', { status: 401 });
+    }
+    return new Response('Error adding site', { status: 500 });
   }
 });
 
@@ -100,10 +108,13 @@ router.post('/api/admin/sites/remove', async (request: IRequest, env: Env) => {
 
     await deleteSite(env, siteToRemove.id);
     console.log(`Removed site: ${url}`);
-    return new Response(`Site ${url} removed successfully`, { status: 200 });
+    return new Response(JSON.stringify({ message: `Site ${url} removed successfully` }), { status: 200 });
   } catch (error) {
     console.error('Error removing site:', error);
-    return new Response('Unauthorized', { status: 401 });
+    if (error.message === 'Unauthorized') {
+      return new Response('Unauthorized', { status: 401 });
+    }
+    return new Response('Error removing site', { status: 500 });
   }
 });
 
@@ -118,7 +129,10 @@ router.get('/api/admin/sites/list', async (request: IRequest, env: Env) => {
     });
   } catch (error) {
     console.error('Error listing sites:', error);
-    return new Response('Unauthorized', { status: 401 });
+    if (error.message === 'Unauthorized') {
+      return new Response('Unauthorized', { status: 401 });
+    }
+    return new Response('Error listing sites', { status: 500 });
   }
 });
 
@@ -164,7 +178,10 @@ router.post('/api/admin/sites/scrape', async (request: IRequest, env: Env) => {
     });
   } catch (error) {
     console.error('Error initiating scraping:', error);
-    return new Response('Unauthorized', { status: 401 });
+    if (error.message === 'Unauthorized') {
+      return new Response('Unauthorized', { status: 401 });
+    }
+    return new Response('Error initiating scraping', { status: 500 });
   }
 });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,10 +1,16 @@
 import { createRouter } from "@respond-run/router";
 
 const globs = import.meta.glob("./routes/**/*.ts", { eager: false });
+import sitesRouter from './routes/api/admin/sites/index';
+
 const handleRoutes = createRouter<Env, ExecutionContext>(globs);
 
 export default {
   async fetch(req: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    const sitesResponse = await sitesRouter.handle(req, env, ctx);
+    if (sitesResponse.status !== 404) { // If sitesRouter handled the request, return its response
+      return sitesResponse;
+    }
     return handleRoutes(req, env, ctx);
   },
 } satisfies ExportedHandler<Env>;


### PR DESCRIPTION
This PR addresses issue #2 by implementing a basic site management and scraping API.

The following endpoints are added under `/api/admin/sites/`:
- `POST /add`: Adds a new URL to the list of sites to be scraped.
- `POST /remove`: Removes a URL from the list of sites.
- `GET /list`: Returns a list of all currently managed sites.
- `POST /scrape`: Triggers a simulated scraping process for a given URL or all managed sites.

**Updates in this commit:**
- Integrated database persistence for sites using `src/models/site.ts`.
- Implemented a more robust scraping and content ingestion logic within `scrapeAndIngest` function. This includes fetching HTML, extracting title and content from common HTML tags (p, h1-h6, li), and saving it as a document.
- Added `nanoid` for generating unique IDs.
- Incorporated `requireAuth` for authentication on all admin site endpoints.
- Improved error handling for API endpoints to return more specific status codes (401 for unauthorized, 500 for internal server errors).
- Added retry logic with exponential backoff for the `scrapeAndIngest` function to handle transient network issues or temporary unavailability of the target website.
- Implemented batch scraping with detailed status feedback, providing information on successful, failed, and rejected scrapes.

**Gaps and Future Improvements:**
- The content extraction in `scrapeAndIngest` can still be improved with a proper HTML parser (e.g., Cheerio, JSDOM) if available in the environment.
- More comprehensive error handling and progress tracking for scraping are needed (e.g., detailed status updates for individual site scrapes).
- Consider batch scraping with status feedback/retry logic.